### PR TITLE
Setup margin for timestamp icon

### DIFF
--- a/src/player/components/Timeline.vue
+++ b/src/player/components/Timeline.vue
@@ -246,7 +246,7 @@ $translationInactiveSliderVrv: 3px;
   .Timestamp {
     height: 6px;
     width: 12px;
-    top: 0;
+    top: 4px;
     transform: translateX(-50%);
   }
 }


### PR DESCRIPTION
It was up 4 px higher than it should be