### PR TITLE
Show Service Name

### DIFF
--- a/src/content-scripts/example/index.ts
+++ b/src/content-scripts/example/index.ts
@@ -4,6 +4,7 @@ import './style.scss';
 console.log('INJECTED content-scripts/example/index.ts');
 
 global.service = 'example';
+global.serviceDisplayName = 'Example';
 global.getRootQuery = (): string => {
   return '.video-container';
 };

--- a/src/content-scripts/funimation/index.ts
+++ b/src/content-scripts/funimation/index.ts
@@ -4,6 +4,7 @@ import './style.scss';
 console.log('INJECTED content-scripts/funimation/index.ts');
 
 global.service = 'funimation';
+global.serviceDisplayName = 'Funimation';
 global.getRootQuery = (): string => {
   return 'body #funimation-player';
 };

--- a/src/content-scripts/vrv/index.ts
+++ b/src/content-scripts/vrv/index.ts
@@ -4,6 +4,7 @@ import './style.scss';
 console.log('INJECTED content-scripts/vrv/index.ts');
 
 global.service = 'vrv';
+global.serviceDisplayName = 'VRV';
 global.getRootQuery = (): string => {
   return 'body>div';
 };

--- a/src/player/components/EpisodeInfo.vue
+++ b/src/player/components/EpisodeInfo.vue
@@ -2,7 +2,7 @@
   <div class="EpisodeInfo" :class="{ visible: hasTriedLoadingEpisodeInfo }">
     <h2>
       {{ showTitle }}
-      <span>&ensp;&bull;&ensp;Anime Skip</span>
+      <span>&ensp;&bull;&ensp;{{ serviceDisplayName }}</span>
     </h2>
     <h1>{{ episodeTitle }}</h1>
     <h3>{{ episodeDetails }}</h3>
@@ -34,6 +34,8 @@ export default class EpisodeInfo extends Vue {
   @Getter() public isEditing!: boolean;
   @Getter() public activeDialog?: string;
   @Getter() public isLoggedIn!: boolean;
+
+  public serviceDisplayName = global.serviceDisplayName ?? 'Unknown';
 
   public get hasTriedLoadingEpisodeInfo(): boolean {
     return (

--- a/types/globals.d.ts
+++ b/types/globals.d.ts
@@ -5,6 +5,7 @@ declare interface ServiceHelpers {
   onVideoChanged(callback: (video: HTMLVideoElement) => void): void;
   Api: Api.Implementation;
   service: 'vrv' | 'funimation' | 'example' | undefined;
+  serviceDisplayName: 'VRV' | 'Funimation' | 'Example' | undefined;
 
   // keyboard-blocker.ts
   addKeyDownListener: (callback: (event: KeyboardEvent) => void) => void;


### PR DESCRIPTION
Instead of saying "Anime Skip" above the episode info, it says the service it's playing on. This is just to not make it seem like we're claiming we're the ones serving the video to the user