### PR TITLE
Load Inferred info when navigating to a video

### DIFF
--- a/src/manifest.js
+++ b/src/manifest.js
@@ -8,7 +8,9 @@ const manifest = {
  * `player_matches` - The URLs that the player interface should be injected onto. This also dictates
  *                    where the keyboard shortcut blocker is injected at since the player is where
  *                    those get added by the service
- * `parent_matches` - The URLs that the parent.ts file should be injected onto
+ * `parent_matches` - The URLs that the parent.ts file should be injected onto. For sites like VRV
+ *                    that use HTML5 History Mode, this has to be a page that is loaded before the
+ *                    page with the player (ie: `https://vrv.co/*` not `https://vrv.co/watch/*`)
  * `page_matches`   - The URLs that the anime skip page_action button should appear when you are
  *                    visiting
  */
@@ -22,7 +24,7 @@ const services = [
   {
     folder: 'vrv',
     player_matches: ['https://static.vrv.co/*'],
-    parent_matches: ['https://vrv.co/watch/*/*'],
+    parent_matches: ['https://vrv.co/*'],
     page_matches: ['https://vrv.co/*'],
   },
   {


### PR DESCRIPTION
Before, you had to refresh the page since it seems like HTML5 history mode messes with the web extension injection. So to fix this, inject the parent script on any VRV page, that way when you navigate to a video, it is already injected, and the request for inferred info succeeds