### PR TITLE
fix(player): toolbar not visible for long episode/show titles

### DIFF
--- a/packages/web-extension/src/content-scripts/player/components/EpisodeInfo.vue
+++ b/packages/web-extension/src/content-scripts/player/components/EpisodeInfo.vue
@@ -10,14 +10,14 @@
       >
         <ThemedLogo class="as-w-8 as-h-8 as-object-contain" />
       </a>
-      <h5 class="as-text-primary as-pt-1 as-line-clamp-2">
+      <h5 class="as-text-primary as-pt-1 as-line-clamp-2" :title="episodeDisplayInfo.show">
         {{ episodeDisplayInfo.show }}
         <span class="as-font-normal as-text-opacity-low"
           >&ensp;&bull;&ensp;{{ serviceDisplayName }}</span
         >
       </h5>
     </div>
-    <h3 class="as-line-clamp-2" title="episodeDisplayInfo.name">{{ episodeDisplayInfo.name }}</h3>
+    <h3 class="as-line-clamp-2" :title="episodeDisplayInfo.name">{{ episodeDisplayInfo.name }}</h3>
     <h6 class="as-text-on-surface as-text-opacity-high">{{ episodeDetails }}</h6>
     <FlatButton v-if="isConnectButtonShowing" transparent @click.stop="showConnectEpisodeDialog">
       <Icon

--- a/packages/web-extension/src/content-scripts/player/components/EpisodeInfo.vue
+++ b/packages/web-extension/src/content-scripts/player/components/EpisodeInfo.vue
@@ -10,14 +10,14 @@
       >
         <ThemedLogo class="as-w-8 as-h-8 as-object-contain" />
       </a>
-      <h5 class="as-text-primary as-pt-1">
+      <h5 class="as-text-primary as-pt-1 as-line-clamp-2">
         {{ episodeDisplayInfo.show }}
         <span class="as-font-normal as-text-opacity-low"
           >&ensp;&bull;&ensp;{{ serviceDisplayName }}</span
         >
       </h5>
     </div>
-    <h3>{{ episodeDisplayInfo.name }}</h3>
+    <h3 class="as-line-clamp-2" title="episodeDisplayInfo.name">{{ episodeDisplayInfo.name }}</h3>
     <h6 class="as-text-on-surface as-text-opacity-high">{{ episodeDetails }}</h6>
     <FlatButton v-if="isConnectButtonShowing" transparent @click.stop="showConnectEpisodeDialog">
       <Icon

--- a/packages/web-extension/src/content-scripts/player/components/Player.vue
+++ b/packages/web-extension/src/content-scripts/player/components/Player.vue
@@ -23,7 +23,9 @@
       >
         <Loading />
       </div>
-      <div class="as-left-content as-pointer-events-none as-pl-8 as-pt-8 as-box-border">
+      <div
+        class="as-left-content as-pointer-events-none as-pl-8 as-pt-8 as-box-border as-overflow-clip"
+      >
         <episode-info />
       </div>
       <notification-center class="as-right-content" />


### PR DESCRIPTION
I made a couple changes:

1. Clamp the line count to 2 for the show and episode titles
2. Set overflow to clip for the episode info
3. Added titles so you can hover over the show/episode name to see the full text

Here's what it looked like before my changes, notice how the toolbar is hidden

![old-long-text](https://user-images.githubusercontent.com/10101283/163726633-a8b3416b-90b3-4827-adbc-53a8a545afb7.png)

With just the line clamping, the toolbar becomes visible:

![trimmed](https://user-images.githubusercontent.com/10101283/163726649-846a54c7-bcf5-437d-98ae-496563446d39.png)

But on a small enough screen, that might still be too tall and push the toolbar off the bottom of the player, so I also added the `overflow: clip` so that the toolbar will never be pushed off the screen if the episode info is too long (here I've disabled line clipping to demonstrate it's working):

![with-clip](https://user-images.githubusercontent.com/10101283/163726707-62a365d1-f934-48c7-9255-80453ba88236.png)

