### PR TITLE
fix(player): incorrect time shown when editing timestamps

### DIFF
--- a/packages/web-extension/src/content-scripts/player/components/TimelineWrapper.vue
+++ b/packages/web-extension/src/content-scripts/player/components/TimelineWrapper.vue
@@ -205,7 +205,7 @@ function toggleHovering(newIsHovering: boolean) {
 const hoverNormalizedAt = ref<number>();
 function updateHoverPosition(event: MouseEvent) {
   const wrapper = wrapperRef.value as HTMLDivElement;
-  const bar = wrapper.querySelector('.bar-container') as HTMLDivElement | null;
+  const bar = wrapper.querySelector('.as-slider') as HTMLDivElement | null;
   const screenWidth = document.body.clientWidth;
   const barWidth = bar?.clientWidth ?? screenWidth;
   const offsetX = (screenWidth - barWidth) / 2;


### PR DESCRIPTION
Fixes #235

### What was the problem?
No child of the `TimelineWrapper` had the class `bar-container`. I am guessing at one point there was, but it was moved into the `Slider` component and changed to `as-bar-container`. This caused the function that computed the hover time to fallback to the screen width every time it was called (instead of using the actual bar width).

When editing timestamps, the bar width shrinks due to additional margins. This difference was ignored as the screen width was always used instead of the actual bar width.

### What was the fix?
Use `as-slider` instead. We could change to `as-bar-container`, but we shouldn't depend on the markup inside of a core UI component having a specific structure / classes. 
